### PR TITLE
Puppetfile/Kibana3: ensure vhost is managed by Puppet

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -109,7 +109,7 @@ mod 'keepalived',
   :ref => 'eb345b6d3b25106cbe166028f2b8dd9974a10230'
 mod 'kibana3',
   :git => 'git://github.com/enovance/kibana3.git',
-  :ref => '64fb5f898a0f062ebf188e53ba613b3b13e9d829'
+  :ref => 'a69bb69ba1478f86d12044491339ce14a56078a3'
 mod 'vcsrepo',
   :git => 'git://github.com/enovance/puppetlabs-vcsrepo.git',
   :ref => '4592bfd59cd5d4795069798a14b483e16c98c1ff'


### PR DESCRIPTION
This patch change the commit ID for Kibana Puppet module, to ensure that
Puppet will manage Kibana3 Apache vhost and not the eDeploy role
anymore.