### PR TITLE
Do not recreate Galera cluster

### DIFF
--- a/lib/facter/galera_bootstrapped.rb
+++ b/lib/facter/galera_bootstrapped.rb
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014 eNovance SAS <licensing@enovance.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Fact: galera_bootstrapped
+#
+Facter.add('galera_bootstrapped') do
+  setcode do
+    FileTest.exists?('/var/lib/mysql/grastate.dat')
+  end
+end

--- a/manifests/database/sql.pp
+++ b/manifests/database/sql.pp
@@ -180,6 +180,11 @@ class cloud::database::sql (
 
       if $::hostname == $galera_master_name {
         $mysql_service_name = 'mysql-bootstrap'
+        if !str2bool($::galera_bootstrapped) {
+          $wsrep_new_cluster = '--wsrep-new-cluster'
+        } else {
+          $wsrep_new_cluster = ''
+        }
       } else {
         $mysql_service_name = 'mariadb'
       }
@@ -247,12 +252,17 @@ class cloud::database::sql (
   # To check that the mysqld support the options you can :
   # strings `which mysqld` | grep wsrep-new-cluster
   # TODO: to be remove as soon as the API 25 is packaged, ie galera 3 ...
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease >= 7 {
+    $mysql_service_notify = Exec['mariadb-sysctl-daemon-reload']
+  } else {
+    $mysql_service_notify = Service['mysqld']
+  }
   file { $mysql_init_file :
     content => template("cloud/database/etc_initd_mysql_${::osfamily}"),
     owner   => 'root',
     mode    => '0755',
     group   => 'root',
-    notify  => Service['mysqld'],
+    notify  => $mysql_service_notify,
     before  => Package[$mysql_server_package_name],
   }
 

--- a/templates/database/etc_initd_mysql_RedHat
+++ b/templates/database/etc_initd_mysql_RedHat
@@ -32,7 +32,7 @@ Group=mysql
 ExecStartPre=/usr/libexec/mariadb-prepare-db-dir %n
 # Note: we set --basedir to prevent probes that might trigger SELinux alarms,
 # per bug #547485
-ExecStart=/usr/bin/mysqld_safe --wsrep-new-cluster --basedir=/usr
+ExecStart=/usr/bin/mysqld_safe <%= @wsrep_new_cluster %> --basedir=/usr
 ExecStartPost=/usr/libexec/mariadb-wait-ready $MAINPID
 
 # Give a reasonable amount of time for the server to start up/shut down


### PR DESCRIPTION
Backport from : https://review.openstack.org/#/c/171555/

Currently if the Galera master node is rebooted after installation process
a new Galera cluster is build because of the --wsrep-new-cluster present
in the systemd.service file. This commit aims to update this behavior
accordingly.

Closes-bug: #1439197
Change-Id: I3e4c339ea073bd18177bd0625d694ddd0151b14c
(cherry picked from commit 735a760c4031e0b32a9aac2f5bcf7af634be7176)