### PR TITLE
Backport galera fix

### DIFF
--- a/lib/facter/galera_bootstrapped.rb
+++ b/lib/facter/galera_bootstrapped.rb
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2014 eNovance SAS <licensing@enovance.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# Fact: galera_bootstrapped
+#
+Facter.add('galera_bootstrapped') do
+  setcode do
+    FileTest.exists?('/var/lib/mysql/grastate.dat')
+  end
+end

--- a/manifests/database/sql.pp
+++ b/manifests/database/sql.pp
@@ -180,6 +180,11 @@ class cloud::database::sql (
 
       if $::hostname == $galera_master_name {
         $mysql_service_name = 'mysql-bootstrap'
+        if !str2bool($::galera_bootstrapped) {
+          $wsrep_new_cluster = '--wsrep-new-cluster'
+        } else {
+          $wsrep_new_cluster = ''
+        }
       } else {
         $mysql_service_name = 'mariadb'
       }
@@ -247,12 +252,17 @@ class cloud::database::sql (
   # To check that the mysqld support the options you can :
   # strings `which mysqld` | grep wsrep-new-cluster
   # TODO: to be remove as soon as the API 25 is packaged, ie galera 3 ...
+  if $::osfamily == 'RedHat' and $::operatingsystemmajrelease >= 7 {
+    $mysql_service_notify = Exec['mariadb-sysctl-daemon-reload']
+  } else {
+    $mysql_service_notify = Service['mysqld']
+  }
   file { $mysql_init_file :
     content => template("cloud/database/etc_initd_mysql_${::osfamily}"),
     owner   => 'root',
     mode    => '0755',
     group   => 'root',
-    notify  => Service['mysqld'],
+    notify  => $mysql_service_notify,
     before  => Package[$mysql_server_package_name],
   }
 

--- a/manifests/database/sql.pp
+++ b/manifests/database/sql.pp
@@ -21,54 +21,143 @@
 #   Array of internal ip of the galera nodes.
 #   Defaults to ['127.0.0.1']
 #
+# [*nova_db_host*]
+#   (optional) Host where user should be allowed all privileges for database.
+#   Defaults to 127.0.0.1
+#
+# [*nova_db_user*]
+#   (optional) Name of nova DB user.
+#   Defaults to trove
+#
+# [*nova_db_password*]
+#   (optional) Password that will be used for the nova db user.
+#   Defaults to 'novapassword'
+#
+# [*nova_db_allowed_hosts*]
+#   (optional) Hosts allowed to use the database
+#   Defaults to ['127.0.0.1']
+#
+# [*neutron_db_host*]
+#   (optional) Host where user should be allowed all privileges for database.
+#   Defaults to 127.0.0.1
+#
+# [*neutron_db_user*]
+#   (optional) Name of neutron DB user.
+#   Defaults to trove
+#
+# [*neutron_db_password*]
+#   (optional) Password that will be used for the neutron db user.
+#   Defaults to 'neutronpassword'
+#
+# [*neutron_db_allowed_hosts*]
+#   (optional) Hosts allowed to use the database
+#   Defaults to ['127.0.0.1']
+#
+# [*trove_db_host*]
+#   (optional) Host where user should be allowed all privileges for database.
+#   Defaults to 127.0.0.1
+#
+# [*trove_db_user*]
+#   (optional) Name of trove DB user.
+#   Defaults to trove
+#
+# [*trove_db_password*]
+#   (optional) Password that will be used for the trove db user.
+#   Defaults to 'trovepassword'
+#
+# [*trove_db_allowed_hosts*]
+#   (optional) Hosts allowed to use the database
+#   Defaults to ['127.0.0.1']
+#
+# [*mysql_root_password*]
+#   (optional) The MySQL root password.
+#   Puppet will attempt to set the root password and update `/root/.my.cnf` with it.
+#   Defaults to 'rootpassword'
+#
+# [*mysql_sys_maint_password*]
+#   (optional) The MySQL debian-sys-maint password.
+#   Debian only parameter.
+#   Defaults to 'sys_maint'
+#
+# [*galera_clustercheck_dbuser*]
+#   (optional) The MySQL username for Galera cluster check (using monitoring database)
+#   Defaults to 'clustercheckdbuser'
+#
+# [*galera_clustercheck_dbpassword*]
+#   (optional) The MySQL password for Galera cluster check
+#   Defaults to 'clustercheckpassword'
+#
+# [*galera_clustercheck_ipaddress*]
+#   (optional) The name or ip address of host running monitoring database (clustercheck)
+#   Defaults to '127.0.0.1'
+#
+# [*open_files_limit*]
+#   (optional) An integer that specifies the open_files_limit for MySQL
+#   Defaults to 65535
+#
+# [*mysql_systemd_override_settings*]
+#   (optional) An hash of setting to override for MariaDB unit file.
+#   Defaults to {}
+#   Example : { 'LimitNOFILE' => 'infinity', 'LimitNPROC' => 4, 'TimeoutSec' => '30' }
+#
 # [*firewall_settings*]
 #   (optional) Allow to add custom parameters to firewall rules
 #   Should be an hash.
 #   Default to {}
 #
 class cloud::database::sql (
-    $api_eth                        = '127.0.0.1',
-    $service_provider               = 'sysv',
-    $galera_master_name             = 'mgmt001',
-    $galera_internal_ips            = ['127.0.0.1'],
-    $galera_gcache                  = '1G',
-    $keystone_db_host               = '127.0.0.1',
-    $keystone_db_user               = 'keystone',
-    $keystone_db_password           = 'keystonepassword',
-    $keystone_db_allowed_hosts      = ['127.0.0.1'],
-    $cinder_db_host                 = '127.0.0.1',
-    $cinder_db_user                 = 'cinder',
-    $cinder_db_password             = 'cinderpassword',
-    $cinder_db_allowed_hosts        = ['127.0.0.1'],
-    $glance_db_host                 = '127.0.0.1',
-    $glance_db_user                 = 'glance',
-    $glance_db_password             = 'glancepassword',
-    $glance_db_allowed_hosts        = ['127.0.0.1'],
-    $heat_db_host                   = '127.0.0.1',
-    $heat_db_user                   = 'heat',
-    $heat_db_password               = 'heatpassword',
-    $heat_db_allowed_hosts          = ['127.0.0.1'],
-    $nova_db_host                   = '127.0.0.1',
-    $nova_db_user                   = 'nova',
-    $nova_db_password               = 'novapassword',
-    $nova_db_allowed_hosts          = ['127.0.0.1'],
-    $neutron_db_host                = '127.0.0.1',
-    $neutron_db_user                = 'neutron',
-    $neutron_db_password            = 'neutronpassword',
-    $neutron_db_allowed_hosts       = ['127.0.0.1'],
-    $trove_db_host                  = '127.0.0.1',
-    $trove_db_user                  = 'trove',
-    $trove_db_password              = 'trovepassword',
-    $trove_db_allowed_hosts         = ['127.0.0.1'],
-    $mysql_root_password            = 'rootpassword',
-    $mysql_sys_maint_password       = 'sys_maint',
-    $galera_clustercheck_dbuser     = 'clustercheckdbuser',
-    $galera_clustercheck_dbpassword = 'clustercheckpassword',
-    $galera_clustercheck_ipaddress  = '127.0.0.1',
-    $firewall_settings              = {},
+    $api_eth                         = '127.0.0.1',
+    $service_provider                = 'sysv',
+    $galera_master_name              = 'mgmt001',
+    $galera_internal_ips             = ['127.0.0.1'],
+    $galera_gcache                   = '1G',
+    $keystone_db_host                = '127.0.0.1',
+    $keystone_db_user                = 'keystone',
+    $keystone_db_password            = 'keystonepassword',
+    $keystone_db_allowed_hosts       = ['127.0.0.1'],
+    $cinder_db_host                  = '127.0.0.1',
+    $cinder_db_user                  = 'cinder',
+    $cinder_db_password              = 'cinderpassword',
+    $cinder_db_allowed_hosts         = ['127.0.0.1'],
+    $glance_db_host                  = '127.0.0.1',
+    $glance_db_user                  = 'glance',
+    $glance_db_password              = 'glancepassword',
+    $glance_db_allowed_hosts         = ['127.0.0.1'],
+    $heat_db_host                    = '127.0.0.1',
+    $heat_db_user                    = 'heat',
+    $heat_db_password                = 'heatpassword',
+    $heat_db_allowed_hosts           = ['127.0.0.1'],
+    $nova_db_host                    = '127.0.0.1',
+    $nova_db_user                    = 'nova',
+    $nova_db_password                = 'novapassword',
+    $nova_db_allowed_hosts           = ['127.0.0.1'],
+    $neutron_db_host                 = '127.0.0.1',
+    $neutron_db_user                 = 'neutron',
+    $neutron_db_password             = 'neutronpassword',
+    $neutron_db_allowed_hosts        = ['127.0.0.1'],
+    $trove_db_host                   = '127.0.0.1',
+    $trove_db_user                   = 'trove',
+    $trove_db_password               = 'trovepassword',
+    $trove_db_allowed_hosts          = ['127.0.0.1'],
+    $mysql_root_password             = 'rootpassword',
+    $mysql_sys_maint_password        = 'sys_maint',
+    $galera_clustercheck_dbuser      = 'clustercheckdbuser',
+    $galera_clustercheck_dbpassword  = 'clustercheckpassword',
+    $galera_clustercheck_ipaddress   = '127.0.0.1',
+    $open_files_limit                = 65535,
+    $mysql_systemd_override_settings = {},
+    $firewall_settings               = {},
 ) {
 
   include 'xinetd'
+
+  if $mysql_systemd_override_settings['LimitNOFILE'] {
+    $open_files_limit_real = $mysql_systemd_override_settings['LimitNOFILE']
+    $mysql_systemd_override_settings_real = $mysql_systemd_override_settings
+  } else {
+    $open_files_limit_real = $open_files_limit
+    $mysql_systemd_override_settings_real = merge($mysql_systemd_override_settings, { 'LimitNOFILE' => $open_files_limit})
+  }
 
   $gcomm_definition = inline_template('<%= @galera_internal_ips.join(",") + "?pc.wait_prim=no" -%>')
 
@@ -209,6 +298,24 @@ class cloud::database::sql (
         require => [Package[$mysql_server_package_name], File[$mysql_server_config_file]]
       }
 
+      if $::operatingsystemrelease >= 7 {
+        file { "/etc/systemd/system/${mysql_service_name}.service.d" :
+          ensure => directory,
+        }
+        file { "/etc/systemd/system/${mysql_service_name}.service.d/custom.conf" :
+          content => template('cloud/database/systemd-custom.conf.erb'),
+          owner   => 'root',
+          mode    => '0755',
+          group   => 'root',
+          notify  => [Service['mysqld'], Exec['mariadb-sysctl-daemon-reload']],
+        }
+        exec { 'mariadb-sysctl-daemon-reload' :
+          command     => '/usr/bin/systemctl daemon-reload',
+          refreshonly => true,
+          notify      => Service['mysqld'],
+        }
+      }
+
     } # RedHat
     'Debian': {
       # Specific to Debian / Ubuntu
@@ -266,7 +373,7 @@ class cloud::database::sql (
     before  => Package[$mysql_server_package_name],
   }
 
-  if($::osfamily == 'Debian'){
+  if $::osfamily == 'Debian' {
     # The startup time can be longer than the default 30s so we take
     # care of it there.  Until this bug is not resolved
     # https://mariadb.atlassian.net/browse/MDEV-5540, we have to do it

--- a/spec/classes/cloud_database_sql_spec.rb
+++ b/spec/classes/cloud_database_sql_spec.rb
@@ -95,6 +95,34 @@ describe 'cloud::database::sql' do
 
     end # configure mysqlchk http replication
 
+    context 'configure override of systemd defaults' do
+      before :each do
+        facts.merge!( :hostname => 'os-ci-test1',
+                      :osfamily => 'RedHat',
+                      :operatingsystemrelease => 7 )
+      end
+      before :each do
+        params.merge!(:mysql_systemd_override_settings => { 'LimitNOFILE' => 666 })
+      end
+
+      it { is_expected.to contain_file('/etc/systemd/system/mysql-bootstrap.service.d/custom.conf').with_content(/[Service]/) }
+      it { is_expected.to contain_file('/etc/systemd/system/mysql-bootstrap.service.d/custom.conf').with_content(/LimitNOFILE=666/) }
+      it { is_expected.to contain_file('/etc/my.cnf').with_content(/open_files_limit                = 666/) }
+    end
+
+    context 'configure open_file_limits' do
+      before :each do
+        facts.merge!( :hostname => 'os-ci-test1',
+                      :osfamily => 'RedHat',
+                      :operatingsystemrelease => 7 )
+      end
+      before :each do
+        params.merge!(:open_files_limit => 666)
+      end
+
+      it { is_expected.to contain_file('/etc/my.cnf').with_content(/open_files_limit                = 666/) }
+    end
+
     context 'configure databases on the galera master server' do
 
       before :each do
@@ -279,7 +307,8 @@ describe 'cloud::database::sql' do
 
   context 'on RedHat platforms' do
     let :facts do
-      { :osfamily => 'RedHat' }
+      { :osfamily => 'RedHat',
+        :operatingsystemrelease => 7 }
     end
 
     let :platform_params do

--- a/templates/database/etc_initd_mysql_RedHat
+++ b/templates/database/etc_initd_mysql_RedHat
@@ -32,7 +32,7 @@ Group=mysql
 ExecStartPre=/usr/libexec/mariadb-prepare-db-dir %n
 # Note: we set --basedir to prevent probes that might trigger SELinux alarms,
 # per bug #547485
-ExecStart=/usr/bin/mysqld_safe --wsrep-new-cluster --basedir=/usr
+ExecStart=/usr/bin/mysqld_safe <%= @wsrep_new_cluster %> --basedir=/usr
 ExecStartPost=/usr/libexec/mariadb-wait-ready $MAINPID
 
 # Give a reasonable amount of time for the server to start up/shut down

--- a/templates/database/mysql.conf.erb
+++ b/templates/database/mysql.conf.erb
@@ -20,7 +20,7 @@ max_heap_table_size             = 128M
 query_cache_type                = 0
 myisam_recover                  = BACKUP
 key_buffer_size                 = 16M
-open-files-limit                = 65535
+open_files_limit                = <%= @open_files_limit_real %>
 table_open_cache                = 1024
 table_definition_cache          = 500
 myisam_sort_buffer_size         = 512M
@@ -37,7 +37,7 @@ innodb_flush_log_at_trx_commit  = 1
 innodb_lock_wait_timeout        = 50
 innodb_thread_concurrency       = 48
 innodb_file_per_table           = 1
-innodb_open_files               = 65535
+innodb_open_files               = <%= @open_files_limit_real %>
 innodb_io_capacity              = 1000
 innodb_file_format              = Barracuda
 innodb_file_format_max          = Barracuda

--- a/templates/database/systemd-custom.conf.erb
+++ b/templates/database/systemd-custom.conf.erb
@@ -1,0 +1,4 @@
+[Service]
+<% @mysql_systemd_override_settings_real.each do |key, value| -%>
+<%= key -%>=<%= value %>
+<% end -%>


### PR DESCRIPTION
    mysql: Enable deployer to set Limits

    This commits aims to enable a deployer to override unit default
    parameters, including limits (LimitNOFILE, etc...), TimeoutSec
    and more.

    Closes-Bug: 1410863
    Change-Id: If712d35fa2ac6a530e6da923b610e33eae11208b
    (cherry picked from commit c3220b9d2d7814c4ad03d1a877f2dc12457a59b5)

    Do not recreate Galera cluster

    Currently if the Galera master node is rebooted after installation process
    a new Galera cluster is build because of the --wsrep-new-cluster present
    in the systemd.service file. This commit aims to update this behavior
    accordingly.

    Closes-bug: #1439197
    Change-Id: I3e4c339ea073bd18177bd0625d694ddd0151b14c
    (cherry picked from commit 735a760c4031e0b32a9aac2f5bcf7af634be7176)