### PR TITLE
puppetmaster.pp: Don't removed httpd vhosts

### DIFF
--- a/manifests/install/puppetmaster.pp
+++ b/manifests/install/puppetmaster.pp
@@ -124,7 +124,10 @@ class cloud::install::puppetmaster (
     include ::puppetdb::master::config
   }
 
-  include ::apache
+  class {'::apache' :
+    purge_configs => false,
+  }
+  include 'apache::mod::wsgi'
   create_resources('apache::vhost', $puppetmaster_vhost_configuration, { 'require' => "Exec[puppet cert generate ${::fqdn}]" })
 
   create_resources('ini_setting', $main_configuration, { 'section' => 'main', 'path' => $puppetconf_path, 'require' => "Package[${puppetmaster_package_name}]", 'notify' => 'Service[httpd]' })

--- a/spec/classes/cloud_install_puppetmaster.rb
+++ b/spec/classes/cloud_install_puppetmaster.rb
@@ -41,6 +41,13 @@ describe 'cloud::install::puppetmaster' do
       is_exptected.to contain_class('puppetdb::master::config')
     end
 
+    it 'configure apache' do
+      is_expected.to contain_class('apache').with(
+        :purge_configs => false
+      )
+      is_expected.to contain_class('apache::mod::wsgi')
+    end
+
     it 'configure the puppet master configuration file' do
       is_expected.to contain_init_setting('certname').with(
         :setting => 'certname',


### PR DESCRIPTION
During configuration of install-server node on step 0 all the vhosts are
removed because the apache class is called without the flag purge_configs
set to false.

Setting "apache::purge_configs: false" in fqdn template is not enough because
the fqdn template are not generated during step 0.