### PR TITLE
Backport : Fix ceph keyring permissions

### DIFF
--- a/manifests/compute/hypervisor.pp
+++ b/manifests/compute/hypervisor.pp
@@ -303,18 +303,16 @@ Host *
 
     # Configure Ceph keyring
     Ceph::Key <<| title == $cinder_rbd_user |>>
-    if defined(Ceph::Key[$cinder_rbd_user]) {
-      ensure_resource(
-        'file',
-        "/etc/ceph/ceph.client.${cinder_rbd_user}.keyring", {
-          owner   => 'root',
-          group   => 'cephkeyring',
-          mode    => '0440',
-          require => Ceph::Key[$cinder_rbd_user],
-          notify  => Service['nova-compute'],
-        }
-      )
-    }
+    ensure_resource(
+      'file',
+      "/etc/ceph/ceph.client.${cinder_rbd_user}.keyring", {
+        owner   => 'root',
+        group   => 'cephkeyring',
+        mode    => '0440',
+        require => Ceph::Key[$cinder_rbd_user],
+        notify  => Service['nova-compute'],
+      }
+    )
 
     Concat::Fragment <<| title == 'ceph-client-os' |>>
   } else {

--- a/manifests/volume/backend/rbd.pp
+++ b/manifests/volume/backend/rbd.pp
@@ -85,14 +85,12 @@ define cloud::volume::backend::rbd (
 
   # Configure Ceph keyring
   Ceph::Key <<| title == $rbd_user |>>
-  if defined(Ceph::Key[$rbd_user]) {
-    ensure_resource('file', "/etc/ceph/ceph.client.${rbd_user}.keyring", {
-      owner   => 'root',
-      group   => 'cephkeyring',
-      mode    => '0440',
-      require => Ceph::Key[$rbd_user],
-      })
-  }
+  ensure_resource('file', "/etc/ceph/ceph.client.${rbd_user}.keyring", {
+    owner => 'root',
+    group => 'cephkeyring',
+    mode => '0440',
+    require => Ceph::Key[$rbd_user],
+  })
 
   Concat::Fragment <<| title == 'ceph-client-os' |>>
 

--- a/spec/classes/cloud_compute_hypervisor_spec.rb
+++ b/spec/classes/cloud_compute_hypervisor_spec.rb
@@ -394,6 +394,11 @@ describe 'cloud::compute::hypervisor' do
           :command => 'usermod -a -G cephkeyring nova',
           :unless  => 'groups nova | grep cephkeyring'
         )
+        is_expected.to contain_file('/etc/ceph/ceph.client.cinder.keyring').with({
+          'owner'  => 'root',
+          'group'  => 'cephkeyring',
+          'mode'   => '0440',
+        })
       end
 
       it 'configure libvirt driver' do

--- a/spec/classes/cloud_volume_storage_spec.rb
+++ b/spec/classes/cloud_volume_storage_spec.rb
@@ -140,6 +140,11 @@ describe 'cloud::volume::storage' do
           :path    => ['/usr/sbin', '/usr/bin', '/bin', '/sbin'],
           :unless  => 'groups cinder | grep cephkeyring'
         )
+        is_expected.to contain_file('/etc/ceph/ceph.client.cinder.keyring').with({
+          'owner'  => 'root',
+          'group'  => 'cephkeyring',
+          'mode'   => '0440',
+        })
       end
     end
 


### PR DESCRIPTION
When ceph osd are not on same nodes than cinder a keyring permissions
problem appear. With this ordering the problem doesn't appear anymore
and all node get the right permissions for the ceph keyring file.

Change-Id: Ib8c5394f56f06192911669d84c172e74d388fafa
(cherry picked from commit a29ff731533b45ca65d6a82b90d90f376fa468af)